### PR TITLE
fix: ignore local api calls

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const { spawnSync } = require('child_process');
 
 const bundledDependencies = new Set([
@@ -15,19 +16,40 @@ const externals = [
   ...Object.keys(packageJSON.peerDependencies),
 ].filter((dependency) => !bundledDependencies.has(dependency));
 
-spawnSync(
-  'npx',
-  [
-    'ncc',
-    'build',
-    '--source-map',
-    '-o',
-    'lib',
-    ...externals.flatMap((dependency) => ['-e', dependency]),
-    './src/index.ts',
-  ],
-  { stdio: 'inherit' },
-);
+require('@vercel/ncc')(path.resolve(__dirname, './src/index.ts'), {
+  // provide a custom cache path or disable caching
+  cache: false,
+  externals,
+  // directory outside of which never to emit assets
+  filterAssetBase: process.cwd(),
+  minify: false,
+  sourceMap: true,
+  assetBuilds: false,
+  sourceMapBasePrefix: '../', // default treats sources as output-relative
+  // when outputting a sourcemap, automatically include
+  // source-map-support in the output file (increases output by 32kB).
+  sourceMapRegister: true, // default
+  watch: false, // default
+  license: '', // default does not generate a license file
+  target: 'es2015', // default
+  v8cache: false, // default
+  quiet: false, // default
+  debugLog: true // default
+}).then(({ code, map, assets }) => {
+  // Assets is an object of asset file names to { source, permissions, symlinks }
+  // expected relative to the output code (if any)
+
+  Object.entries(assets).forEach(([fileName, {source, permissions}]) => {
+    const destFileName = path.resolve('./lib/', fileName)
+    fs.mkdirSync(path.dirname(destFileName), {recursive: true})
+    fs.writeFileSync(destFileName, source, {
+      mode: permissions
+    });
+  })
+
+  fs.writeFileSync('./lib/index.js', code);
+})
+
 
 fs.writeFileSync(
   './lib/package.json',
@@ -36,6 +58,7 @@ fs.writeFileSync(
       ...packageJSON,
       scripts: {},
       main: 'index.js',
+      types: "index.d.ts",
       private: false,
       files: ['**/*'],
       dependencies: externals.reduce((acc, dependency) => {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "Payload CMS plugin for automatic Blurhash encoding of images",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "private": true,
   "repository": {
     "type": "git",
@@ -13,7 +14,7 @@
   "scripts": {
     "build": "node build.js",
     "format": "prettier --write \"src/**/*.ts\"",
-    "prepare": "yarn build"
+    "prepare": "node build.js"
   },
   "files": ["lib/**/*"],
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ const computeBlurhash = (pluginOptions?: BlurhashPluginOptions) => {
 
   return (incomingConfig: Config): Config => {
     const hook: CollectionBeforeChangeHook = async ({ data, req }) => {
-      if (!req.collection) {
+      if (!req.collection && req.payloadAPI !== "local") {
         return data;
       }
 


### PR DESCRIPTION
Hello!

Thanks for creating this library.

I've been trying to upload media from the payload local API, and I've found the payload local API doesn't always set `req.collection` which means this plugin bails out due to `req.collection` not existing.

e.g 
```js
await payload.init({
	secret: PAYLOAD_SECRET,
	local: true,
});

const blob = await fetch(
	"https://www.google.com/images/branding/googlelogo/2x/googlelogo_light_color_272x92dp.png"
).then((response) => response.blob());

const arrayBuffer = await blob.arrayBuffer();
const buffer = await Buffer.from(arrayBuffer, "binary");

await payload.create({
	collection: "media",
	data: {},
	file: {
		data: buffer,
		mimetype: blob.type,
		name: "test.png",
		size: buffer.length,
	},
});

```

I've also updated the build script to use the NCC node api, as the build script would not run for me locally and removed the requirement to use yarn to run the build script.

Thanks!