### PR TITLE
fix: hide the blurhash field on the admin interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,9 @@ const computeBlurhash = (pluginOptions?: BlurhashPluginOptions) => {
               {
                 name: 'blurhash',
                 type: 'text',
+                admin: {
+                  hidden: true
+                }
               },
             ],
             hooks: {


### PR DESCRIPTION
As mentioned in the Issue #242 , the blurash text field should not be visible on the admin interface while viewing a media item.